### PR TITLE
Add ds (data science) archetype: thin core, commented catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,12 @@ jobs:
           uv run --frozen nuv new api-smoke --at /tmp/api-smoke --archetype fastapi
           cd /tmp/api-smoke && uv sync --frozen && uv run --frozen pytest
 
+      - name: Integration smoke test (ds)
+        if: matrix.python-version == '3.14'
+        run: |
+          uv run --frozen nuv new ds-smoke --at /tmp/ds-smoke --archetype ds
+          cd /tmp/ds-smoke && uv sync --frozen && uv run --frozen pytest && uv run --frozen ruff check . && uv run --frozen ty check
+
       - name: Build wheel for distribution smoke tests
         if: matrix.python-version == '3.14'
         run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         if: matrix.python-version == '3.14'
         run: |
           uv run --frozen nuv new ds-smoke --at /tmp/ds-smoke --archetype ds
-          cd /tmp/ds-smoke && uv sync --frozen && uv run --frozen pytest && uv run --frozen ruff check . && uv run --frozen ty check
+          cd /tmp/ds-smoke && uv sync --frozen && uv run --frozen pytest && uv run --frozen ruff check . && uv run --frozen ruff format --check . && uv run --frozen ty check
 
       - name: Build wheel for distribution smoke tests
         if: matrix.python-version == '3.14'

--- a/.gitignore
+++ b/.gitignore
@@ -764,3 +764,63 @@ cython_debug/
 .agents
 .opencode
 .worktrees
+.copilot
+.cursor
+.aider*
+.continue
+
+### AI / ML / Data Science development
+# Datasets — version with DVC/LFS rather than git
+data/
+*.parquet
+*.feather
+*.arrow
+*.npy
+*.npz
+*.pkl
+*.pickle
+*.duckdb
+warehouse.db
+_delta_log/
+
+# Trained models & checkpoints
+models/
+checkpoints/
+*.ckpt
+*.pt
+*.pth
+*.bin
+*.safetensors
+*.onnx
+*.pb
+*.tflite
+*.gguf
+*.ggml
+*.joblib
+*.h5
+*.hdf5
+
+# Experiment tracking & orchestration
+mlruns/
+mlartifacts/
+wandb/
+.neptune/
+lightning_logs/
+ray_results/
+catboost_info/
+outputs/
+.hydra/
+multirun/
+
+# Notebook & ML library caches
+.virtual_documents/
+__marimo__/
+.keras/
+.torch/
+.cache/huggingface/
+nltk_data/
+
+# Secrets
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ nuv new <name> --at <path>                  # creates at an explicit path
 nuv new <name> --archetype spark            # PySpark 4 project with notebooks
 nuv new <name> --archetype fastapi          # FastAPI + Granian + Docker
 nuv new <name> --archetype polars           # Polars + DuckDB + Delta Lake for local data work
+nuv new <name> --archetype ds               # Data science: thin core + commented DS/ML/LLM catalog
 nuv new <name> --python-version 3.13        # override default Python version
 nuv new <name> --install none               # scaffold + sync, skip tool install
 nuv new <name> --install command-only       # log install command, do not execute (default)
@@ -224,6 +225,57 @@ uv run marimo edit notebooks/explore.py
 - You want a marimo notebook for exploration with the I/O helpers pre-wired.
 
 **Pick `spark` instead when** the dataset doesn't fit on one machine, or you need a long-running cluster.
+
+### ds
+
+A batteries-included data science project. **Manifesto: all of what you need or want, but off by default.**
+
+```bash
+nuv new my-ds-project --archetype ds
+```
+
+`pyproject.toml` ships a deliberately thin active core — numpy, pandas, Arrow, a Click CLI, and typed config — alongside a large, curated, **commented-out** catalog of the rest of the modern stack: classical ML (scikit-learn, scipy, statsmodels, XGBoost/LightGBM/CatBoost), deep learning & neural nets (PyTorch, TensorFlow, Keras, JAX/Flax/Optax), LLMs & NLP (transformers, datasets, accelerate, peft, vLLM, OpenAI/Anthropic clients, LangChain, LlamaIndex, spaCy), vector stores, viz, and experiment tracking (MLflow, Weights & Biases, DVC, Hydra, Ray). Uncomment a line, run `uv sync`, and uv resolves it against everything already locked.
+
+```
+my-ds-project/
+├── main.py                          # Click CLI entry point
+├── pyproject.toml                   # thin core + commented catalog
+├── src/my_ds_project/
+│   ├── __init__.py
+│   ├── _logging.py
+│   ├── config.py                    # Pydantic settings (paths, seed, ...)
+│   ├── data.py                      # CSV/Parquet/JSON I/O + quick-look helpers
+│   └── main.py
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py
+│   └── test_data.py
+├── notebooks/
+│   ├── explore.ipynb                # Jupyter / IPython
+│   └── explore_marimo.py            # marimo
+├── data/
+│   ├── raw/                         # inputs (gitignored)
+│   └── processed/                   # derived data (gitignored)
+└── models/                          # trained artifacts (gitignored)
+```
+
+Default Python version: 3.13 (broadest compatibility across the DS/ML ecosystem).
+
+```bash
+uv run pytest          # passing, 100% coverage
+uv run ruff check .    # clean
+uv run ty check        # clean
+```
+
+Notebooks ship in two flavors and are an optional dependency group (Jupyter/IPython **and** marimo):
+
+```bash
+uv sync --group notebooks
+uv run jupyter lab notebooks/                  # Jupyter / IPython
+uv run marimo edit notebooks/explore_marimo.py # marimo
+```
+
+The generated `.gitignore` is comprehensive for AI/ML work: datasets, model weights and checkpoints (`*.safetensors`, `*.ckpt`, `*.gguf`, ...), experiment-tracking dirs (`mlruns/`, `wandb/`, `lightning_logs/`), notebook and library caches, and `.env` secrets.
 
 ## Quality out of the box
 

--- a/src/nuv/cli.py
+++ b/src/nuv/cli.py
@@ -6,7 +6,7 @@ from nuv._logging import configure
 from nuv.commands.new import validate_python_version
 
 LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
-ARCHETYPES = ("script", "spark", "fastapi", "polars")
+ARCHETYPES = ("script", "spark", "fastapi", "polars", "ds")
 INSTALL_MODES = ("editable", "none", "command-only")
 
 
@@ -56,7 +56,7 @@ def cli(ctx: click.Context, log_level: str) -> None:
     default=None,
     metavar="VERSION",
     callback=_validate_python_version,
-    help="Python version (default depends on archetype — script=3.14, spark=3.13, fastapi=3.14, polars=3.14). Must be MAJOR.MINOR format.",
+    help="Python version (default depends on archetype — script=3.14, spark=3.13, fastapi=3.14, polars=3.14, ds=3.13). Must be MAJOR.MINOR format.",
 )
 @click.option(
     "--install",

--- a/src/nuv/commands/new.py
+++ b/src/nuv/commands/new.py
@@ -24,7 +24,7 @@ def validate_name(name: str) -> str:
 
 _TEMPLATES_ROOT = Path(__file__).parent.parent / "templates"
 DEFAULT_PYTHON_VERSION = "3.14"
-DEFAULT_PYTHON_VERSIONS = {"script": "3.14", "spark": "3.13", "fastapi": "3.14", "polars": "3.14"}
+DEFAULT_PYTHON_VERSIONS = {"script": "3.14", "spark": "3.13", "fastapi": "3.14", "polars": "3.14", "ds": "3.13"}
 
 
 def validate_python_version(version: str) -> str:
@@ -139,7 +139,87 @@ def generate_jupyter_notebook(name: str, *, python_version: str = DEFAULT_PYTHON
     return json.dumps(notebook, indent=1) + "\n"
 
 
-VALID_ARCHETYPES = ("script", "spark", "fastapi", "polars")
+def generate_ds_notebook(name: str, *, python_version: str = DEFAULT_PYTHON_VERSION) -> str:
+    """Build a starter Jupyter/IPython notebook for the data science archetype.
+
+    Generated programmatically instead of via .tpl because .ipynb JSON
+    braces conflict with str.format() placeholders.
+    """
+
+    def _code_cell(source: list[str]) -> dict:
+        return {
+            "cell_type": "code",
+            "execution_count": None,
+            "metadata": {},
+            "outputs": [],
+            "source": source,
+        }
+
+    def _md_cell(source: list[str]) -> dict:
+        return {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": source,
+        }
+
+    cells = [
+        _md_cell([f"# {name} — Exploration Notebook"]),
+        _code_cell(
+            [
+                "import numpy as np\n",
+                "import pandas as pd",
+            ]
+        ),
+        _md_cell(["## Create a sample DataFrame"]),
+        _code_cell(
+            [
+                "rng = np.random.default_rng(42)\n",
+                'df = pd.DataFrame({"x": [1, 2, 3], "y": ["a", "b", "c"], "z": rng.random(3)})\n',
+                "df",
+            ]
+        ),
+        _md_cell(["## Summarize"]),
+        _code_cell(
+            [
+                "df.describe(include='all')",
+            ]
+        ),
+        _md_cell(
+            [
+                "## Plot\n",
+                "\n",
+                "Uncomment `matplotlib` in `pyproject.toml`, `uv sync`, then:",
+            ]
+        ),
+        _code_cell(
+            [
+                "# import matplotlib.pyplot as plt\n",
+                "# df.plot(x='x', y='x', kind='bar')\n",
+                "# plt.show()",
+            ]
+        ),
+    ]
+
+    notebook = {
+        "cells": cells,
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {
+                "name": "python",
+                "version": f"{python_version}.0",
+            },
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    return json.dumps(notebook, indent=1) + "\n"
+
+
+VALID_ARCHETYPES = ("script", "spark", "fastapi", "polars", "ds")
 
 
 def scaffold_files(
@@ -179,6 +259,8 @@ def scaffold_files(
             _scaffold_spark(target, template_vars=template_vars, name=name, module_name=module_name)
         case "polars":
             _scaffold_polars(target, template_vars=template_vars, module_name=module_name)
+        case "ds":
+            _scaffold_ds(target, template_vars=template_vars, name=name, module_name=module_name)
         case _:  # fastapi — validated by VALID_ARCHETYPES above
             _scaffold_fastapi(target, template_vars=template_vars, module_name=module_name)
 
@@ -272,6 +354,36 @@ def _scaffold_polars(
 
     (target / "data" / "raw").mkdir(parents=True)
     (target / "data" / "features").mkdir(parents=True)
+
+
+def _scaffold_ds(
+    target: Path,
+    *,
+    template_vars: dict[str, str],
+    name: str,
+    module_name: str,
+) -> None:
+    pkg_dir = target / "src" / module_name
+    pkg_dir.mkdir(parents=True)
+    write_with_trailing_newline(pkg_dir / "__init__.py", render_template("init.py.tpl", **template_vars))
+    write_with_trailing_newline(pkg_dir / "_logging.py", render_template("_logging.py.tpl", **template_vars))
+    write_with_trailing_newline(pkg_dir / "config.py", render_template("config.py.tpl", **template_vars))
+    write_with_trailing_newline(pkg_dir / "data.py", render_template("data.py.tpl", **template_vars))
+    write_with_trailing_newline(pkg_dir / "main.py", render_template("main.py.tpl", **template_vars))
+
+    tests_dir = target / "tests"
+    write_with_trailing_newline(tests_dir / "conftest.py", render_template("conftest.py.tpl", **template_vars))
+    write_with_trailing_newline(tests_dir / "test_data.py", render_template("test_data.py.tpl", **template_vars))
+
+    # notebooks/ — Jupyter/IPython (.ipynb) and marimo (.py) side by side
+    notebooks_dir = target / "notebooks"
+    notebooks_dir.mkdir()
+    write_with_trailing_newline(notebooks_dir / "explore.ipynb", generate_ds_notebook(name, python_version=template_vars["python_version"]))
+    write_with_trailing_newline(notebooks_dir / "explore_marimo.py", render_template("notebooks/explore_marimo.py.tpl", **template_vars))
+
+    (target / "data" / "raw").mkdir(parents=True)
+    (target / "data" / "processed").mkdir(parents=True)
+    (target / "models").mkdir()
 
 
 def run_uv_sync(target: Path) -> None:

--- a/src/nuv/commands/new.py
+++ b/src/nuv/commands/new.py
@@ -63,32 +63,54 @@ def write_with_trailing_newline(path: Path, content: str) -> None:
     path.write_text(normalized, encoding="utf-8")
 
 
-def generate_jupyter_notebook(name: str, *, python_version: str = DEFAULT_PYTHON_VERSION) -> str:
-    """Build a starter Jupyter notebook as JSON.
+def _nb_code_cell(source: list[str]) -> dict:
+    return {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": source,
+    }
+
+
+def _nb_md_cell(source: list[str]) -> dict:
+    return {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": source,
+    }
+
+
+def _notebook_json(cells: list[dict], *, python_version: str) -> str:
+    """Wrap notebook cells in the nbformat v4 envelope and serialize to JSON.
 
     Generated programmatically instead of via .tpl because .ipynb JSON
     braces conflict with str.format() placeholders.
     """
+    notebook = {
+        "cells": cells,
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {
+                "name": "python",
+                "version": f"{python_version}.0",
+            },
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    return json.dumps(notebook, indent=1) + "\n"
 
-    def _code_cell(source: list[str]) -> dict:
-        return {
-            "cell_type": "code",
-            "execution_count": None,
-            "metadata": {},
-            "outputs": [],
-            "source": source,
-        }
 
-    def _md_cell(source: list[str]) -> dict:
-        return {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": source,
-        }
-
+def generate_jupyter_notebook(name: str, *, python_version: str = DEFAULT_PYTHON_VERSION) -> str:
+    """Build a starter Jupyter notebook (PySpark) as JSON."""
     cells = [
-        _md_cell([f"# {name} — Exploration Notebook"]),
-        _code_cell(
+        _nb_md_cell([f"# {name} — Exploration Notebook"]),
+        _nb_code_cell(
             [
                 "from pyspark.sql import SparkSession\n",
                 "\n",
@@ -96,102 +118,64 @@ def generate_jupyter_notebook(name: str, *, python_version: str = DEFAULT_PYTHON
                 "spark",
             ]
         ),
-        _md_cell(["## Create a sample DataFrame"]),
-        _code_cell(
+        _nb_md_cell(["## Create a sample DataFrame"]),
+        _nb_code_cell(
             [
                 'data = [("alice", 1), ("bob", 2), ("charlie", 3)]\n',
                 'df = spark.createDataFrame(data, ["name", "value"])\n',
                 "df.show()",
             ]
         ),
-        _md_cell(["## Filter"]),
-        _code_cell(
+        _nb_md_cell(["## Filter"]),
+        _nb_code_cell(
             [
                 "filtered = df.filter(df.value > 1)\n",
                 "filtered.show()",
             ]
         ),
-        _md_cell(["## Group By"]),
-        _code_cell(
+        _nb_md_cell(["## Group By"]),
+        _nb_code_cell(
             [
                 'grouped = df.groupBy("name").sum("value")\n',
                 "grouped.show()",
             ]
         ),
     ]
-
-    notebook = {
-        "cells": cells,
-        "metadata": {
-            "kernelspec": {
-                "display_name": "Python 3",
-                "language": "python",
-                "name": "python3",
-            },
-            "language_info": {
-                "name": "python",
-                "version": f"{python_version}.0",
-            },
-        },
-        "nbformat": 4,
-        "nbformat_minor": 5,
-    }
-    return json.dumps(notebook, indent=1) + "\n"
+    return _notebook_json(cells, python_version=python_version)
 
 
 def generate_ds_notebook(name: str, *, python_version: str = DEFAULT_PYTHON_VERSION) -> str:
-    """Build a starter Jupyter/IPython notebook for the data science archetype.
-
-    Generated programmatically instead of via .tpl because .ipynb JSON
-    braces conflict with str.format() placeholders.
-    """
-
-    def _code_cell(source: list[str]) -> dict:
-        return {
-            "cell_type": "code",
-            "execution_count": None,
-            "metadata": {},
-            "outputs": [],
-            "source": source,
-        }
-
-    def _md_cell(source: list[str]) -> dict:
-        return {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": source,
-        }
-
+    """Build a starter Jupyter/IPython notebook (pandas) for the ds archetype."""
     cells = [
-        _md_cell([f"# {name} — Exploration Notebook"]),
-        _code_cell(
+        _nb_md_cell([f"# {name} — Exploration Notebook"]),
+        _nb_code_cell(
             [
                 "import numpy as np\n",
                 "import pandas as pd",
             ]
         ),
-        _md_cell(["## Create a sample DataFrame"]),
-        _code_cell(
+        _nb_md_cell(["## Create a sample DataFrame"]),
+        _nb_code_cell(
             [
                 "rng = np.random.default_rng(42)\n",
                 'df = pd.DataFrame({"x": [1, 2, 3], "y": ["a", "b", "c"], "z": rng.random(3)})\n',
                 "df",
             ]
         ),
-        _md_cell(["## Summarize"]),
-        _code_cell(
+        _nb_md_cell(["## Summarize"]),
+        _nb_code_cell(
             [
-                "df.describe(include='all')",
+                'df.describe(include="all")',
             ]
         ),
-        _md_cell(
+        _nb_md_cell(
             [
                 "## Plot\n",
                 "\n",
                 "Uncomment `matplotlib` in `pyproject.toml`, `uv sync`, then:",
             ]
         ),
-        _code_cell(
+        _nb_code_cell(
             [
                 "# import matplotlib.pyplot as plt\n",
                 "# df.plot(x='x', y='x', kind='bar')\n",
@@ -199,24 +183,7 @@ def generate_ds_notebook(name: str, *, python_version: str = DEFAULT_PYTHON_VERS
             ]
         ),
     ]
-
-    notebook = {
-        "cells": cells,
-        "metadata": {
-            "kernelspec": {
-                "display_name": "Python 3",
-                "language": "python",
-                "name": "python3",
-            },
-            "language_info": {
-                "name": "python",
-                "version": f"{python_version}.0",
-            },
-        },
-        "nbformat": 4,
-        "nbformat_minor": 5,
-    }
-    return json.dumps(notebook, indent=1) + "\n"
+    return _notebook_json(cells, python_version=python_version)
 
 
 VALID_ARCHETYPES = ("script", "spark", "fastapi", "polars", "ds")
@@ -381,9 +348,12 @@ def _scaffold_ds(
     write_with_trailing_newline(notebooks_dir / "explore.ipynb", generate_ds_notebook(name, python_version=template_vars["python_version"]))
     write_with_trailing_newline(notebooks_dir / "explore_marimo.py", render_template("notebooks/explore_marimo.py.tpl", **template_vars))
 
-    (target / "data" / "raw").mkdir(parents=True)
-    (target / "data" / "processed").mkdir(parents=True)
-    (target / "models").mkdir()
+    # Scratch dirs with .gitkeep so the tree survives a fresh clone while the
+    # .gitignore keeps their contents out of version control.
+    for rel in ("data/raw", "data/processed", "models"):
+        keep_dir = target / rel
+        keep_dir.mkdir(parents=True)
+        (keep_dir / ".gitkeep").write_text("", encoding="utf-8")
 
 
 def run_uv_sync(target: Path) -> None:

--- a/src/nuv/commands/new.py
+++ b/src/nuv/commands/new.py
@@ -178,7 +178,7 @@ def generate_ds_notebook(name: str, *, python_version: str = DEFAULT_PYTHON_VERS
         _nb_code_cell(
             [
                 "# import matplotlib.pyplot as plt\n",
-                "# df.plot(x='x', y='x', kind='bar')\n",
+                "# df.plot(x='x', y='z', kind='bar')\n",
                 "# plt.show()",
             ]
         ),

--- a/src/nuv/templates/ds/_logging.py.tpl
+++ b/src/nuv/templates/ds/_logging.py.tpl
@@ -1,0 +1,12 @@
+import logging
+import sys
+
+LOG_FORMAT = "%(levelname)s %(name)s: %(message)s"
+
+
+def configure(level: str = "WARNING") -> None:
+    logging.basicConfig(
+        level=level,
+        format=LOG_FORMAT,
+        stream=sys.stderr,
+    )

--- a/src/nuv/templates/ds/config.py.tpl
+++ b/src/nuv/templates/ds/config.py.tpl
@@ -1,9 +1,13 @@
 from pathlib import Path
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    # Namespace env vars (e.g. {module_name}_random_seed) so ambient names
+    # like RANDOM_SEED / APP_NAME / LOG_LEVEL don't clobber these defaults.
+    model_config = SettingsConfigDict(env_prefix="{module_name}_")
+
     app_name: str = "{name}"
     log_level: str = "INFO"
     data_root: Path = Path("data")

--- a/src/nuv/templates/ds/config.py.tpl
+++ b/src/nuv/templates/ds/config.py.tpl
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    app_name: str = "{name}"
+    log_level: str = "INFO"
+    data_root: Path = Path("data")
+    raw_dir: Path = Path("data/raw")
+    processed_dir: Path = Path("data/processed")
+    models_dir: Path = Path("models")
+    random_seed: int = 42

--- a/src/nuv/templates/ds/conftest.py.tpl
+++ b/src/nuv/templates/ds/conftest.py.tpl
@@ -1,0 +1,7 @@
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def sample_df() -> pd.DataFrame:
+    return pd.DataFrame({{"x": [1, 2, 3], "y": ["a", "b", "c"]}})

--- a/src/nuv/templates/ds/data.py.tpl
+++ b/src/nuv/templates/ds/data.py.tpl
@@ -3,6 +3,9 @@
 Read/write CSV, Parquet, and JSON, plus a couple of quick-look helpers for
 the REPL and notebooks. Swap pandas for polars (uncomment it in
 pyproject.toml) once a dataset outgrows comfortable in-memory pandas.
+
+Note: JSON does not preserve dtypes (datetimes round-trip as strings, not
+``datetime64``). Reach for Parquet when you need full-fidelity round-trips.
 """
 
 from pathlib import Path
@@ -30,6 +33,7 @@ def write(df: pd.DataFrame, path: str | Path, **kwargs) -> None:
     elif suffix == ".parquet":
         df.to_parquet(path, **kwargs)
     elif suffix == ".json":
+        kwargs.setdefault("date_format", "iso")
         df.to_json(path, **kwargs)
     else:
         raise ValueError(f"Unsupported format: {{suffix}}")

--- a/src/nuv/templates/ds/data.py.tpl
+++ b/src/nuv/templates/ds/data.py.tpl
@@ -1,0 +1,45 @@
+"""Tabular I/O helpers built on pandas.
+
+Read/write CSV, Parquet, and JSON, plus a couple of quick-look helpers for
+the REPL and notebooks. Swap pandas for polars (uncomment it in
+pyproject.toml) once a dataset outgrows comfortable in-memory pandas.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def read_csv(path: str | Path, **kwargs) -> pd.DataFrame:
+    return pd.read_csv(path, **kwargs)
+
+
+def read_parquet(path: str | Path, **kwargs) -> pd.DataFrame:
+    return pd.read_parquet(path, **kwargs)
+
+
+def read_json(path: str | Path, **kwargs) -> pd.DataFrame:
+    return pd.read_json(path, **kwargs)
+
+
+def write(df: pd.DataFrame, path: str | Path, **kwargs) -> None:
+    path = Path(path)
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        df.to_csv(path, index=False, **kwargs)
+    elif suffix == ".parquet":
+        df.to_parquet(path, **kwargs)
+    elif suffix == ".json":
+        df.to_json(path, **kwargs)
+    else:
+        raise ValueError(f"Unsupported format: {{suffix}}")
+
+
+def preview(df: pd.DataFrame, n: int = 10) -> None:
+    print(df.head(n))
+
+
+def summary(df: pd.DataFrame) -> None:
+    n_rows, n_cols = df.shape
+    print(f"Rows: {{n_rows:,}}    Columns: {{n_cols:,}}")
+    print(df.dtypes)

--- a/src/nuv/templates/ds/gitignore.tpl
+++ b/src/nuv/templates/ds/gitignore.tpl
@@ -68,9 +68,11 @@ ipython_config.py
 .virtual_documents/
 __marimo__/
 
-# --- Data (keep it out of git; version it with DVC/LFS if you must) ----------
-data/
-!data/.gitkeep
+# --- Data: keep the directory tree, ignore its contents ----------------------
+# (version actual datasets with DVC/LFS if you must)
+data/**
+!data/**/
+!data/**/.gitkeep
 *.csv
 *.tsv
 *.parquet
@@ -92,8 +94,9 @@ warehouse.db
 _delta_log/
 
 # --- Models & checkpoints ----------------------------------------------------
-models/
-!models/.gitkeep
+models/**
+!models/**/
+!models/**/.gitkeep
 checkpoints/
 *.ckpt
 *.pt

--- a/src/nuv/templates/ds/gitignore.tpl
+++ b/src/nuv/templates/ds/gitignore.tpl
@@ -1,0 +1,127 @@
+# --- Editors & OS ----------------------------------------------------------
+.idea/
+*.iml
+.vscode/
+.DS_Store
+.directory
+*.swp
+*.swo
+*~
+
+# --- AI coding agents --------------------------------------------------------
+.claude/
+.codex/
+.copilot/
+.amp/
+.opencode/
+.cursor/
+.aider*
+.continue/
+
+# --- Python ------------------------------------------------------------------
+.venv/
+venv/
+env/
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# --- Tooling caches ----------------------------------------------------------
+.uv/
+.uvx/
+.ruff_cache/
+.pytest_cache/
+.mypy_cache/
+.dmypy.json
+.pyre/
+.pytype/
+.cache/
+.hypothesis/
+
+# --- Coverage & test reports -------------------------------------------------
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+.tox/
+.nox/
+
+# --- Environment & secrets ---------------------------------------------------
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+secrets.toml
+.secrets/
+
+# --- Notebooks ---------------------------------------------------------------
+.ipynb_checkpoints/
+*/.ipynb_checkpoints/*
+profile_default/
+ipython_config.py
+.virtual_documents/
+__marimo__/
+
+# --- Data (keep it out of git; version it with DVC/LFS if you must) ----------
+data/
+!data/.gitkeep
+*.csv
+*.tsv
+*.parquet
+*.feather
+*.arrow
+*.orc
+*.avro
+*.h5
+*.hdf5
+*.npy
+*.npz
+*.pkl
+*.pickle
+*.db
+*.sqlite
+*.sqlite3
+*.duckdb
+warehouse.db
+_delta_log/
+
+# --- Models & checkpoints ----------------------------------------------------
+models/
+!models/.gitkeep
+checkpoints/
+*.ckpt
+*.pt
+*.pth
+*.bin
+*.safetensors
+*.onnx
+*.pb
+*.tflite
+*.gguf
+*.ggml
+*.joblib
+
+# --- Experiment tracking & orchestration -------------------------------------
+mlruns/
+mlartifacts/
+wandb/
+.neptune/
+lightning_logs/
+ray_results/
+catboost_info/
+.dvc/cache/
+outputs/
+.hydra/
+multirun/
+
+# --- Caches from ML libraries ------------------------------------------------
+.keras/
+.torch/
+.cache/huggingface/
+nltk_data/

--- a/src/nuv/templates/ds/main.py.tpl
+++ b/src/nuv/templates/ds/main.py.tpl
@@ -1,0 +1,22 @@
+import logging
+
+import click
+
+log = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    "--log-level",
+    default="WARNING",
+    show_default=True,
+    help="Logging level.",
+)
+def main(log_level: str) -> None:
+    from {module_name}._logging import configure
+    configure(log_level)
+    log.info("Starting {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nuv/templates/ds/main.py.tpl
+++ b/src/nuv/templates/ds/main.py.tpl
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 )
 def main(log_level: str) -> None:
     from {module_name}._logging import configure
+
     configure(log_level)
     log.info("Starting {name}")
 

--- a/src/nuv/templates/ds/notebooks/explore_marimo.py.tpl
+++ b/src/nuv/templates/ds/notebooks/explore_marimo.py.tpl
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.4"
+__generated_with = "0.23.8"
 app = marimo.App(width="medium")
 
 

--- a/src/nuv/templates/ds/notebooks/explore_marimo.py.tpl
+++ b/src/nuv/templates/ds/notebooks/explore_marimo.py.tpl
@@ -1,0 +1,31 @@
+import marimo
+
+__generated_with = "0.23.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import numpy as np
+    import pandas as pd
+
+    from {module_name}.data import preview, summary
+
+    return np, pd, preview, summary
+
+
+@app.cell
+def _(pd):
+    df = pd.DataFrame({{"x": [1, 2, 3], "y": ["a", "b", "c"]}})
+    df
+    return (df,)
+
+
+@app.cell
+def _(df, summary):
+    summary(df)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/nuv/templates/ds/pyproject.toml.tpl
+++ b/src/nuv/templates/ds/pyproject.toml.tpl
@@ -1,0 +1,174 @@
+[project]
+name = "{name}"
+version = "0.1.0"
+description = "A data science project scaffolded by nuv."
+readme = "README.md"
+requires-python = ">={python_version}"
+# ---------------------------------------------------------------------------
+# Manifesto: all of what you need or want, but off by default.
+#
+# The active set below is a deliberately thin core — numpy, pandas, arrow,
+# a CLI, and typed config. Everything else lives in the curated, commented
+# catalog further down: classical ML, deep learning, neural nets, LLMs,
+# experiment tracking, viz, the works. Uncomment a line, run `uv sync`, and
+# uv resolves it against everything already locked. Add weight only when you
+# reach for it — your environment stays lean until you decide otherwise.
+# ---------------------------------------------------------------------------
+dependencies = [
+    "numpy>=2.4.0",
+    "pandas>=2.2.0",
+    "pyarrow>=18.0.0",
+    "pydantic-settings>=2.14.0",
+    "click>=8.3.3",
+]
+
+# ---------------------------------------------------------------------------
+# The catalog. Uncomment what you need, then `uv sync`.
+# Versions are floors for the latest major releases as of mid-2026; bump
+# freely. `uv add <pkg>` is the other way in — it edits this list for you.
+# ---------------------------------------------------------------------------
+
+# --- Dataframes, formats & local engines ----------------------------------
+#   "polars>=1.40.1",          # fast multi-threaded dataframes (Arrow-native)
+#   "duckdb>=1.5.2",           # in-process OLAP SQL over Parquet/Arrow/Polars
+#   "deltalake>=1.5.1",        # Delta Lake tables without the JVM
+#   "fastparquet>=2024.11.0",  # alternative Parquet engine for pandas
+#   "openpyxl>=3.1.5",         # read/write .xlsx
+#   "xlsxwriter>=3.2.0",       # write richly formatted .xlsx
+#   "sqlalchemy>=2.0.36",      # SQL toolkit / ORM
+#   "fsspec>=2025.5.0",        # filesystem abstraction (s3, gcs, http, ...)
+#   "s3fs>=2025.5.0",          # S3-backed fsspec
+
+# --- Classical / tabular ML ------------------------------------------------
+#   "scikit-learn>=1.8.0",     # the workhorse: models, pipelines, metrics
+#   "scipy>=1.17.0",           # scientific computing primitives
+#   "statsmodels>=0.14.4",     # statistical models & tests
+#   "xgboost>=3.0.0",          # gradient-boosted trees
+#   "lightgbm>=4.6.0",         # fast gradient boosting
+#   "catboost>=1.2.7",         # gradient boosting with native categoricals
+#   "imbalanced-learn>=0.13.0",# resampling for imbalanced datasets
+#   "optuna>=4.2.0",           # hyperparameter optimization
+
+# --- Deep learning & neural nets -------------------------------------------
+#   "torch>=2.11.0",           # PyTorch
+#   "torchvision>=0.26.0",     # vision models, transforms, datasets
+#   "torchaudio>=2.11.0",      # audio I/O and transforms for PyTorch
+#   "lightning>=2.5.0",        # PyTorch Lightning training loops
+#   "tensorflow>=2.20.0",      # TensorFlow
+#   "keras>=3.11.0",           # multi-backend Keras (TF / JAX / PyTorch)
+#   "jax>=0.7.0",              # composable transforms + XLA
+#   "flax>=0.10.0",            # neural nets on JAX
+#   "optax>=0.2.4",            # gradient processing & optimization for JAX
+#   "einops>=0.8.1",           # readable tensor reshaping/rearranging
+
+# --- LLMs, transformers & NLP ----------------------------------------------
+#   "transformers>=5.9.0",         # Hugging Face models
+#   "datasets>=4.0.0",             # streaming/loading datasets
+#   "tokenizers>=0.22.0",          # fast tokenizers
+#   "accelerate>=1.10.0",          # device placement & distributed training
+#   "peft>=0.18.0",                # parameter-efficient fine-tuning (LoRA, ...)
+#   "safetensors>=0.6.0",          # safe, fast tensor serialization
+#   "huggingface-hub>=0.36.0",     # pull/push models & datasets
+#   "sentence-transformers>=5.1.0",# embeddings & semantic search
+#   "bitsandbytes>=0.48.0",        # 8-/4-bit quantization
+#   "vllm>=0.11.0",                # high-throughput LLM serving
+#   "tiktoken>=0.8.0",             # OpenAI BPE tokenizer
+#   "openai>=2.0.0",               # OpenAI API client
+#   "anthropic>=0.50.0",           # Anthropic API client
+#   "ollama>=0.4.0",               # local model runner client
+#   "langchain>=0.4.0",            # LLM application framework
+#   "langchain-community>=0.4.0",  # community integrations for LangChain
+#   "langgraph>=0.4.0",            # stateful agent/graph orchestration
+#   "llama-index>=0.13.0",         # data framework for LLM apps / RAG
+#   "spacy>=3.8.0",                # industrial-strength NLP
+#   "nltk>=3.9.1",                 # classic NLP toolkit
+#   "gensim>=4.3.3",               # topic modelling & word vectors
+
+# --- Vector stores & retrieval ---------------------------------------------
+#   "faiss-cpu>=1.9.0",        # similarity search over dense vectors
+#   "chromadb>=0.6.0",         # embeddings database
+#   "qdrant-client>=1.12.0",   # Qdrant vector DB client
+
+# --- Images, audio & geo ---------------------------------------------------
+#   "pillow>=11.0.0",          # image I/O & manipulation
+#   "opencv-python>=4.11.0",   # computer vision
+#   "scikit-image>=0.25.0",    # image processing
+#   "librosa>=0.11.0",         # audio analysis
+#   "geopandas>=1.0.1",        # geospatial dataframes
+
+# --- Experiment tracking, orchestration & scaling --------------------------
+#   "mlflow>=3.0.0",           # experiment tracking & model registry
+#   "wandb>=0.19.0",           # experiment tracking & dashboards
+#   "dvc>=3.60.0",             # data & model version control
+#   "hydra-core>=1.3.2",       # hierarchical config management
+#   "ray[default]>=2.40.0",    # distributed compute / tuning / serving
+#   "dask[complete]>=2025.5.0",# parallel & out-of-core computing
+
+# --- Visualization ---------------------------------------------------------
+#   "matplotlib>=3.10.0",      # the foundational plotting library
+#   "seaborn>=0.13.2",         # statistical visualization
+#   "plotly>=6.0.0",           # interactive charts
+#   "altair>=5.5.0",           # declarative (Vega-Lite) charts
+#   "bokeh>=3.6.0",            # interactive web plots
+
+# --- Utilities -------------------------------------------------------------
+#   "tqdm>=4.67.0",            # progress bars
+#   "rich>=14.0.0",            # rich terminal output
+#   "python-dotenv>=1.0.1",    # load .env files
+
+[project.scripts]
+{name} = "{module_name}.main:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
+    "ruff>=0.15.12",
+    "ty>=0.0.34",
+    "ipython>=9.0.0",
+]
+# Jupyter / IPython + marimo notebooks. `uv sync --group notebooks` to enable.
+notebooks = [
+    "jupyterlab>=4.5.7",
+    "notebook>=7.5.0",
+    "ipykernel>=7.0.0",
+    "ipywidgets>=8.1.5",
+    "jupytext>=1.17.0",
+    "marimo>=0.23.4",
+]
+
+[tool.uv]
+managed = true
+
+[tool.pytest.ini_options]
+addopts = "--cov={module_name} --cov-report=term-missing --cov-fail-under=90"
+
+[tool.ruff]
+target-version = "py{python_version_nodot}"
+line-length = 180
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+# A bare expression on the last line of a marimo cell is its rendered output.
+"notebooks/*.py" = ["B018"]
+
+[tool.ty.src]
+# Notebook deps live in the optional `notebooks` group and aren't installed
+# by a default `uv sync`, so keep them out of the type-check pass.
+exclude = ["notebooks"]
+
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = ["if __name__ == .__main__.:"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/{module_name}"]
+include = ["main.py"]
+
+[build-system]
+requires = ["hatchling>=1.29.0"]
+build-backend = "hatchling.build"

--- a/src/nuv/templates/ds/pyproject.toml.tpl
+++ b/src/nuv/templates/ds/pyproject.toml.tpl
@@ -20,15 +20,13 @@ dependencies = [
     "pyarrow>=24.0.0",
     "pydantic-settings>=2.14.1",
     "click>=8.4.1",
-]
-
-# ---------------------------------------------------------------------------
-# The catalog. Uncomment what you need, then `uv sync`.
-# Versions are floors for the latest stable PyPI releases as of June 1, 2026.
-# `uv add <pkg>` is the other way in — it edits this list for you.
-# ---------------------------------------------------------------------------
-
-# --- Dataframes, formats & local engines ----------------------------------
+    # -----------------------------------------------------------------------
+    # The catalog lives *inside* this array: uncomment a line (drop the
+    # leading `#`) and it becomes a valid dependency, then run `uv sync`.
+    # Versions are floors for the latest stable PyPI releases as of June 1,
+    # 2026. `uv add <pkg>` is the other way in — it edits this list for you.
+    # -----------------------------------------------------------------------
+    # --- Dataframes, formats & local engines ----------------------------------
 #   "polars>=1.41.2",          # fast multi-threaded dataframes (Arrow-native)
 #   "duckdb>=1.5.3",           # in-process OLAP SQL over Parquet/Arrow/Polars
 #   "deltalake>=1.6.0",        # Delta Lake tables without the JVM
@@ -115,6 +113,7 @@ dependencies = [
 #   "tqdm>=4.67.3",            # progress bars
 #   "rich>=15.0.0",            # rich terminal output
 #   "python-dotenv>=1.2.2",    # load .env files
+]
 
 [project.scripts]
 {name} = "{module_name}.main:main"

--- a/src/nuv/templates/ds/pyproject.toml.tpl
+++ b/src/nuv/templates/ds/pyproject.toml.tpl
@@ -15,106 +15,106 @@ requires-python = ">={python_version}"
 # reach for it — your environment stays lean until you decide otherwise.
 # ---------------------------------------------------------------------------
 dependencies = [
-    "numpy>=2.4.0",
-    "pandas>=2.2.0",
-    "pyarrow>=18.0.0",
-    "pydantic-settings>=2.14.0",
-    "click>=8.3.3",
+    "numpy>=2.4.6",
+    "pandas>=3.0.3",
+    "pyarrow>=24.0.0",
+    "pydantic-settings>=2.14.1",
+    "click>=8.4.1",
 ]
 
 # ---------------------------------------------------------------------------
 # The catalog. Uncomment what you need, then `uv sync`.
-# Versions are floors for the latest major releases as of mid-2026; bump
-# freely. `uv add <pkg>` is the other way in — it edits this list for you.
+# Versions are floors for the latest stable PyPI releases as of June 1, 2026.
+# `uv add <pkg>` is the other way in — it edits this list for you.
 # ---------------------------------------------------------------------------
 
 # --- Dataframes, formats & local engines ----------------------------------
-#   "polars>=1.40.1",          # fast multi-threaded dataframes (Arrow-native)
-#   "duckdb>=1.5.2",           # in-process OLAP SQL over Parquet/Arrow/Polars
-#   "deltalake>=1.5.1",        # Delta Lake tables without the JVM
-#   "fastparquet>=2024.11.0",  # alternative Parquet engine for pandas
+#   "polars>=1.41.2",          # fast multi-threaded dataframes (Arrow-native)
+#   "duckdb>=1.5.3",           # in-process OLAP SQL over Parquet/Arrow/Polars
+#   "deltalake>=1.6.0",        # Delta Lake tables without the JVM
+#   "fastparquet>=2026.5.0",   # alternative Parquet engine for pandas
 #   "openpyxl>=3.1.5",         # read/write .xlsx
-#   "xlsxwriter>=3.2.0",       # write richly formatted .xlsx
-#   "sqlalchemy>=2.0.36",      # SQL toolkit / ORM
-#   "fsspec>=2025.5.0",        # filesystem abstraction (s3, gcs, http, ...)
-#   "s3fs>=2025.5.0",          # S3-backed fsspec
+#   "xlsxwriter>=3.2.9",       # write richly formatted .xlsx
+#   "sqlalchemy>=2.0.50",      # SQL toolkit / ORM
+#   "fsspec>=2026.4.0",        # filesystem abstraction (s3, gcs, http, ...)
+#   "s3fs>=2026.4.0",          # S3-backed fsspec
 
 # --- Classical / tabular ML ------------------------------------------------
 #   "scikit-learn>=1.8.0",     # the workhorse: models, pipelines, metrics
-#   "scipy>=1.17.0",           # scientific computing primitives
-#   "statsmodels>=0.14.4",     # statistical models & tests
-#   "xgboost>=3.0.0",          # gradient-boosted trees
+#   "scipy>=1.17.1",           # scientific computing primitives
+#   "statsmodels>=0.14.6",     # statistical models & tests
+#   "xgboost>=3.2.0",          # gradient-boosted trees
 #   "lightgbm>=4.6.0",         # fast gradient boosting
-#   "catboost>=1.2.7",         # gradient boosting with native categoricals
-#   "imbalanced-learn>=0.13.0",# resampling for imbalanced datasets
-#   "optuna>=4.2.0",           # hyperparameter optimization
+#   "catboost>=1.2.10",        # gradient boosting with native categoricals
+#   "imbalanced-learn>=0.14.1",# resampling for imbalanced datasets
+#   "optuna>=4.9.0",           # hyperparameter optimization
 
 # --- Deep learning & neural nets -------------------------------------------
-#   "torch>=2.11.0",           # PyTorch
-#   "torchvision>=0.26.0",     # vision models, transforms, datasets
+#   "torch>=2.12.0",           # PyTorch
+#   "torchvision>=0.27.0",     # vision models, transforms, datasets
 #   "torchaudio>=2.11.0",      # audio I/O and transforms for PyTorch
-#   "lightning>=2.5.0",        # PyTorch Lightning training loops
-#   "tensorflow>=2.20.0",      # TensorFlow
-#   "keras>=3.11.0",           # multi-backend Keras (TF / JAX / PyTorch)
-#   "jax>=0.7.0",              # composable transforms + XLA
-#   "flax>=0.10.0",            # neural nets on JAX
-#   "optax>=0.2.4",            # gradient processing & optimization for JAX
-#   "einops>=0.8.1",           # readable tensor reshaping/rearranging
+#   "lightning>=2.6.5",        # PyTorch Lightning training loops
+#   "tensorflow>=2.21.0",      # TensorFlow
+#   "keras>=3.14.1",           # multi-backend Keras (TF / JAX / PyTorch)
+#   "jax>=0.10.1",             # composable transforms + XLA
+#   "flax>=0.12.7",            # neural nets on JAX
+#   "optax>=0.2.8",            # gradient processing & optimization for JAX
+#   "einops>=0.8.2",           # readable tensor reshaping/rearranging
 
 # --- LLMs, transformers & NLP ----------------------------------------------
 #   "transformers>=5.9.0",         # Hugging Face models
-#   "datasets>=4.0.0",             # streaming/loading datasets
-#   "tokenizers>=0.22.0",          # fast tokenizers
-#   "accelerate>=1.10.0",          # device placement & distributed training
-#   "peft>=0.18.0",                # parameter-efficient fine-tuning (LoRA, ...)
-#   "safetensors>=0.6.0",          # safe, fast tensor serialization
-#   "huggingface-hub>=0.36.0",     # pull/push models & datasets
-#   "sentence-transformers>=5.1.0",# embeddings & semantic search
-#   "bitsandbytes>=0.48.0",        # 8-/4-bit quantization
-#   "vllm>=0.11.0",                # high-throughput LLM serving
-#   "tiktoken>=0.8.0",             # OpenAI BPE tokenizer
-#   "openai>=2.0.0",               # OpenAI API client
-#   "anthropic>=0.50.0",           # Anthropic API client
-#   "ollama>=0.4.0",               # local model runner client
-#   "langchain>=0.4.0",            # LLM application framework
-#   "langchain-community>=0.4.0",  # community integrations for LangChain
-#   "langgraph>=0.4.0",            # stateful agent/graph orchestration
-#   "llama-index>=0.13.0",         # data framework for LLM apps / RAG
-#   "spacy>=3.8.0",                # industrial-strength NLP
-#   "nltk>=3.9.1",                 # classic NLP toolkit
-#   "gensim>=4.3.3",               # topic modelling & word vectors
+#   "datasets>=4.8.5",             # streaming/loading datasets
+#   "tokenizers>=0.23.1",          # fast tokenizers
+#   "accelerate>=1.13.0",          # device placement & distributed training
+#   "peft>=0.19.1",                # parameter-efficient fine-tuning (LoRA, ...)
+#   "safetensors>=0.7.0",          # safe, fast tensor serialization
+#   "huggingface-hub>=1.17.0",     # pull/push models & datasets
+#   "sentence-transformers>=5.5.1",# embeddings & semantic search
+#   "bitsandbytes>=0.49.2",        # 8-/4-bit quantization
+#   "vllm>=0.22.0",                # high-throughput LLM serving
+#   "tiktoken>=0.13.0",            # OpenAI BPE tokenizer
+#   "openai>=2.38.0",              # OpenAI API client
+#   "anthropic>=0.105.2",          # Anthropic API client
+#   "ollama>=0.6.2",               # local model runner client
+#   "langchain>=1.3.2",            # LLM application framework
+#   "langchain-community>=0.4.2",  # community integrations for LangChain
+#   "langgraph>=1.2.2",            # stateful agent/graph orchestration
+#   "llama-index>=0.14.22",        # data framework for LLM apps / RAG
+#   "spacy>=3.8.14",               # industrial-strength NLP
+#   "nltk>=3.9.4",                 # classic NLP toolkit
+#   "gensim>=4.4.0",               # topic modelling & word vectors
 
 # --- Vector stores & retrieval ---------------------------------------------
-#   "faiss-cpu>=1.9.0",        # similarity search over dense vectors
-#   "chromadb>=0.6.0",         # embeddings database
-#   "qdrant-client>=1.12.0",   # Qdrant vector DB client
+#   "faiss-cpu>=1.14.2",       # similarity search over dense vectors
+#   "chromadb>=1.5.9",         # embeddings database
+#   "qdrant-client>=1.18.0",   # Qdrant vector DB client
 
 # --- Images, audio & geo ---------------------------------------------------
-#   "pillow>=11.0.0",          # image I/O & manipulation
-#   "opencv-python>=4.11.0",   # computer vision
-#   "scikit-image>=0.25.0",    # image processing
+#   "pillow>=12.2.0",          # image I/O & manipulation
+#   "opencv-python>=4.13.0.92",# computer vision
+#   "scikit-image>=0.26.0",    # image processing
 #   "librosa>=0.11.0",         # audio analysis
-#   "geopandas>=1.0.1",        # geospatial dataframes
+#   "geopandas>=1.1.3",        # geospatial dataframes
 
 # --- Experiment tracking, orchestration & scaling --------------------------
-#   "mlflow>=3.0.0",           # experiment tracking & model registry
-#   "wandb>=0.19.0",           # experiment tracking & dashboards
-#   "dvc>=3.60.0",             # data & model version control
+#   "mlflow>=3.13.0",          # experiment tracking & model registry
+#   "wandb>=0.27.0",           # experiment tracking & dashboards
+#   "dvc>=3.67.1",             # data & model version control
 #   "hydra-core>=1.3.2",       # hierarchical config management
-#   "ray[default]>=2.40.0",    # distributed compute / tuning / serving
-#   "dask[complete]>=2025.5.0",# parallel & out-of-core computing
+#   "ray[default]>=2.55.1",    # distributed compute / tuning / serving
+#   "dask[complete]>=2026.3.0",# parallel & out-of-core computing
 
 # --- Visualization ---------------------------------------------------------
-#   "matplotlib>=3.10.0",      # the foundational plotting library
+#   "matplotlib>=3.10.9",      # the foundational plotting library
 #   "seaborn>=0.13.2",         # statistical visualization
-#   "plotly>=6.0.0",           # interactive charts
-#   "altair>=5.5.0",           # declarative (Vega-Lite) charts
-#   "bokeh>=3.6.0",            # interactive web plots
+#   "plotly>=6.7.0",           # interactive charts
+#   "altair>=6.1.0",           # declarative (Vega-Lite) charts
+#   "bokeh>=3.9.0",            # interactive web plots
 
 # --- Utilities -------------------------------------------------------------
-#   "tqdm>=4.67.0",            # progress bars
-#   "rich>=14.0.0",            # rich terminal output
-#   "python-dotenv>=1.0.1",    # load .env files
+#   "tqdm>=4.67.3",            # progress bars
+#   "rich>=15.0.0",            # rich terminal output
+#   "python-dotenv>=1.2.2",    # load .env files
 
 [project.scripts]
 {name} = "{module_name}.main:main"
@@ -123,18 +123,18 @@ dependencies = [
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
-    "ruff>=0.15.12",
-    "ty>=0.0.34",
-    "ipython>=9.0.0",
+    "ruff>=0.15.15",
+    "ty>=0.0.40",
+    "ipython>=9.14.0",
 ]
 # Jupyter / IPython + marimo notebooks. `uv sync --group notebooks` to enable.
 notebooks = [
     "jupyterlab>=4.5.7",
-    "notebook>=7.5.0",
-    "ipykernel>=7.0.0",
-    "ipywidgets>=8.1.5",
-    "jupytext>=1.17.0",
-    "marimo>=0.23.4",
+    "notebook>=7.5.6",
+    "ipykernel>=7.2.0",
+    "ipywidgets>=8.1.8",
+    "jupytext>=1.19.3",
+    "marimo>=0.23.8",
 ]
 
 [tool.uv]

--- a/src/nuv/templates/ds/readme.md.tpl
+++ b/src/nuv/templates/ds/readme.md.tpl
@@ -1,0 +1,74 @@
+# {name}
+
+A data science project scaffolded by [nuv](https://github.com/stevencarpenter/nuv).
+
+## Manifesto: all of what you need or want, but off by default
+
+`pyproject.toml` ships a thin active core — numpy, pandas, Arrow, a CLI, and
+typed config — alongside a curated, commented catalog of the rest of the
+modern stack: classical ML, deep learning, neural nets, LLMs, experiment
+tracking, and visualization. Uncomment a line, run `uv sync`, and uv resolves
+it against everything already locked. Your environment stays lean until you
+decide otherwise.
+
+## Setup
+
+```bash
+uv sync
+```
+
+### Notebooks (optional)
+
+```bash
+uv sync --group notebooks
+```
+
+## Usage
+
+```bash
+uv run python main.py --help
+uv run python main.py --log-level INFO
+```
+
+## Development
+
+```bash
+uv run pytest          # run tests
+uv run ruff check .    # lint
+uv run ruff format .   # format
+uv run ty check .      # type check
+```
+
+## Notebooks
+
+Two notebook front-ends ship side by side — pick your flavor.
+
+```bash
+# Jupyter / IPython
+uv run jupyter lab notebooks/
+
+# marimo (reactive, git-friendly .py notebooks)
+uv run marimo edit notebooks/explore_marimo.py
+```
+
+## Layout
+
+```
+{name}/
+├── main.py                       # Click CLI entry point
+├── pyproject.toml                # thin core + commented catalog
+├── src/{module_name}/
+│   ├── _logging.py
+│   ├── config.py                 # Pydantic settings (paths, seed, ...)
+│   └── data.py                   # CSV/Parquet/JSON I/O + quick-look helpers
+├── tests/
+│   ├── conftest.py
+│   └── test_data.py
+├── notebooks/
+│   ├── explore.ipynb             # Jupyter / IPython
+│   └── explore_marimo.py         # marimo
+├── data/
+│   ├── raw/                      # inputs (gitignored)
+│   └── processed/                # derived data (gitignored)
+└── models/                       # trained artifacts (gitignored)
+```

--- a/src/nuv/templates/ds/test_data.py.tpl
+++ b/src/nuv/templates/ds/test_data.py.tpl
@@ -1,0 +1,66 @@
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+from pandas.testing import assert_frame_equal
+
+from {module_name}._logging import configure
+from {module_name}.config import Settings
+from {module_name}.data import (
+    preview,
+    read_csv,
+    read_json,
+    read_parquet,
+    summary,
+    write,
+)
+from {module_name}.main import main
+
+
+def test_read_parquet_roundtrip(tmp_path):
+    df = pd.DataFrame({{"x": [1, 2, 3], "y": ["a", "b", "c"]}})
+    path = tmp_path / "test.parquet"
+    write(df, path)
+    assert_frame_equal(read_parquet(path), df)
+
+
+def test_read_csv_roundtrip(tmp_path):
+    df = pd.DataFrame({{"x": [1, 2, 3], "y": ["a", "b", "c"]}})
+    path = tmp_path / "test.csv"
+    write(df, path)
+    assert_frame_equal(read_csv(path), df)
+
+
+def test_read_json_roundtrip(tmp_path):
+    df = pd.DataFrame({{"x": [1, 2, 3], "y": ["a", "b", "c"]}})
+    path = tmp_path / "test.json"
+    write(df, path)
+    assert_frame_equal(read_json(path), df)
+
+
+def test_write_unsupported_format(sample_df, tmp_path):
+    path = tmp_path / "test.xyz"
+    with pytest.raises(ValueError, match="Unsupported format"):
+        write(sample_df, path)
+
+
+def test_preview_does_not_raise(sample_df):
+    preview(sample_df)
+
+
+def test_summary_does_not_raise(sample_df):
+    summary(sample_df)
+
+
+def test_settings_defaults():
+    settings = Settings()
+    assert settings.app_name == "{name}"
+    assert settings.random_seed == 42
+
+
+def test_configure_does_not_raise():
+    configure("INFO")
+
+
+def test_main_cli_runs():
+    result = CliRunner().invoke(main, ["--log-level", "INFO"])
+    assert result.exit_code == 0

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -1255,9 +1255,9 @@ def test_scaffold_files_ds_creates_expected_files(tmp_path: Path) -> None:
     assert (target / "tests" / "test_data.py").exists()
     assert (target / "notebooks" / "explore.ipynb").exists()
     assert (target / "notebooks" / "explore_marimo.py").exists()
-    assert (target / "data" / "raw").exists()
-    assert (target / "data" / "processed").exists()
-    assert (target / "models").exists()
+    assert (target / "data" / "raw" / ".gitkeep").exists()
+    assert (target / "data" / "processed" / ".gitkeep").exists()
+    assert (target / "models" / ".gitkeep").exists()
 
 
 def test_scaffold_files_ds_pyproject_thin_core_and_catalog(tmp_path: Path) -> None:
@@ -1294,6 +1294,8 @@ def test_scaffold_files_ds_data_module(tmp_path: Path) -> None:
     assert "def summary" in data_content
     config = (target / "src" / "my_ds_app" / "config.py").read_text()
     assert "pydantic_settings" in config
+    # env_prefix isolates settings so ambient env vars don't clobber defaults
+    assert 'env_prefix="my_ds_app_"' in config
 
 
 def test_scaffold_files_ds_gitignore_has_ml_entries(tmp_path: Path) -> None:

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -1265,23 +1265,43 @@ def test_scaffold_files_ds_pyproject_thin_core_and_catalog(tmp_path: Path) -> No
     target.mkdir()
     scaffold_files(target, name="my-ds-app", module_name="my_ds_app", archetype="ds", python_version="3.13")
     pyproject = (target / "pyproject.toml").read_text()
-    # thin active core
-    assert "numpy>=2.4.6" in pyproject
-    assert "pandas>=3.0.3" in pyproject
-    assert "pyarrow>=24.0.0" in pyproject
-    assert "click>=8.4.1" in pyproject
+    # thin active core (assert names, not version floors, so version bumps
+    # don't churn this test)
+    for pkg in ("numpy>=", "pandas>=", "pyarrow>=", "pydantic-settings>=", "click>="):
+        assert pkg in pyproject
     # commented catalog — present but off by default
     assert '#   "torch>=' in pyproject
     assert '#   "transformers>=' in pyproject
     assert '#   "scikit-learn>=' in pyproject
     assert '#   "jax>=' in pyproject
     # notebooks group covers Jupyter + IPython + marimo
-    assert "jupyterlab>=4.5.7" in pyproject
-    assert "ipykernel>=7.2.0" in pyproject
-    assert "marimo>=0.23.8" in pyproject
+    for pkg in ("jupyterlab>=", "ipykernel>=", "marimo>="):
+        assert pkg in pyproject
     assert "py313" in pyproject
     assert 'packages = ["src/my_ds_app"]' in pyproject
     assert 'build-backend = "hatchling.build"' in pyproject
+
+
+def test_scaffold_files_ds_pyproject_is_valid_toml_and_uncomment_works(tmp_path: Path) -> None:
+    """The commented catalog must live inside `dependencies` so that simply
+    dropping a leading `#` yields valid TOML (the core 'uncomment a line'
+    promise)."""
+    import tomllib
+
+    target = tmp_path / "my-ds-app"
+    target.mkdir()
+    scaffold_files(target, name="my-ds-app", module_name="my_ds_app", archetype="ds", python_version="3.13")
+    raw = (target / "pyproject.toml").read_text()
+
+    # As shipped: parses, thin core only.
+    parsed = tomllib.loads(raw)
+    assert any(dep.startswith("numpy") for dep in parsed["project"]["dependencies"])
+    assert not any("torch" in dep for dep in parsed["project"]["dependencies"])
+
+    # Uncomment a catalog line -> still valid TOML, now an active dependency.
+    uncommented = raw.replace('#   "torch>=', '    "torch>=')
+    parsed2 = tomllib.loads(uncommented)
+    assert any(dep.startswith("torch") for dep in parsed2["project"]["dependencies"])
 
 
 def test_scaffold_files_ds_data_module(tmp_path: Path) -> None:

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -1266,10 +1266,10 @@ def test_scaffold_files_ds_pyproject_thin_core_and_catalog(tmp_path: Path) -> No
     scaffold_files(target, name="my-ds-app", module_name="my_ds_app", archetype="ds", python_version="3.13")
     pyproject = (target / "pyproject.toml").read_text()
     # thin active core
-    assert "numpy>=2.4.0" in pyproject
-    assert "pandas>=2.2.0" in pyproject
-    assert "pyarrow>=18.0.0" in pyproject
-    assert "click>=8.3.3" in pyproject
+    assert "numpy>=2.4.6" in pyproject
+    assert "pandas>=3.0.3" in pyproject
+    assert "pyarrow>=24.0.0" in pyproject
+    assert "click>=8.4.1" in pyproject
     # commented catalog — present but off by default
     assert '#   "torch>=' in pyproject
     assert '#   "transformers>=' in pyproject
@@ -1277,8 +1277,8 @@ def test_scaffold_files_ds_pyproject_thin_core_and_catalog(tmp_path: Path) -> No
     assert '#   "jax>=' in pyproject
     # notebooks group covers Jupyter + IPython + marimo
     assert "jupyterlab>=4.5.7" in pyproject
-    assert "ipykernel>=7.0.0" in pyproject
-    assert "marimo>=0.23.4" in pyproject
+    assert "ipykernel>=7.2.0" in pyproject
+    assert "marimo>=0.23.8" in pyproject
     assert "py313" in pyproject
     assert 'packages = ["src/my_ds_app"]' in pyproject
     assert 'build-backend = "hatchling.build"' in pyproject

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -11,6 +11,7 @@ from nuv.commands.new import (
     DEFAULT_PYTHON_VERSION,
     DEFAULT_PYTHON_VERSIONS,
     build_tool_install_command,
+    generate_ds_notebook,
     generate_jupyter_notebook,
     render_template,
     resolve_target,
@@ -1194,3 +1195,191 @@ def test_run_new_polars_uses_default_python_314(tmp_path: Path) -> None:
     call_kwargs = mock_scaffold.call_args[1]
     assert call_kwargs["python_version"] == "3.14"
     assert call_kwargs["archetype"] == "polars"
+
+
+# ---------------------------------------------------------------------------
+# ds (data science) archetype — generate_ds_notebook
+# ---------------------------------------------------------------------------
+
+
+def test_generate_ds_notebook_valid_json() -> None:
+    import json
+
+    result = generate_ds_notebook("my-ds-app")
+    notebook = json.loads(result)
+    assert notebook["nbformat"] == 4
+    assert notebook["cells"][0]["cell_type"] == "markdown"
+    assert "my-ds-app" in notebook["cells"][0]["source"][0]
+
+
+def test_generate_ds_notebook_imports_pandas() -> None:
+    result = generate_ds_notebook("my-ds-app")
+    assert "import pandas as pd" in result
+    assert "import numpy as np" in result
+
+
+def test_generate_ds_notebook_python_version() -> None:
+    import json
+
+    result = generate_ds_notebook("my-ds-app", python_version="3.13")
+    notebook = json.loads(result)
+    assert notebook["metadata"]["language_info"]["version"] == "3.13.0"
+
+
+# ---------------------------------------------------------------------------
+# ds archetype — scaffold_files
+# ---------------------------------------------------------------------------
+
+
+def test_default_python_versions_ds() -> None:
+    assert DEFAULT_PYTHON_VERSIONS["ds"] == "3.13"
+
+
+def test_scaffold_files_ds_creates_expected_files(tmp_path: Path) -> None:
+    target = tmp_path / "my-ds-app"
+    target.mkdir()
+    scaffold_files(target, name="my-ds-app", module_name="my_ds_app", archetype="ds", python_version="3.13")
+
+    assert (target / ".python-version").exists()
+    assert (target / ".gitignore").exists()
+    assert (target / "main.py").exists()
+    assert (target / "pyproject.toml").exists()
+    assert (target / "README.md").exists()
+    assert (target / "src" / "my_ds_app" / "__init__.py").exists()
+    assert (target / "src" / "my_ds_app" / "_logging.py").exists()
+    assert (target / "src" / "my_ds_app" / "config.py").exists()
+    assert (target / "src" / "my_ds_app" / "data.py").exists()
+    assert (target / "src" / "my_ds_app" / "main.py").exists()
+    assert (target / "tests" / "__init__.py").exists()
+    assert (target / "tests" / "conftest.py").exists()
+    assert (target / "tests" / "test_data.py").exists()
+    assert (target / "notebooks" / "explore.ipynb").exists()
+    assert (target / "notebooks" / "explore_marimo.py").exists()
+    assert (target / "data" / "raw").exists()
+    assert (target / "data" / "processed").exists()
+    assert (target / "models").exists()
+
+
+def test_scaffold_files_ds_pyproject_thin_core_and_catalog(tmp_path: Path) -> None:
+    target = tmp_path / "my-ds-app"
+    target.mkdir()
+    scaffold_files(target, name="my-ds-app", module_name="my_ds_app", archetype="ds", python_version="3.13")
+    pyproject = (target / "pyproject.toml").read_text()
+    # thin active core
+    assert "numpy>=2.4.0" in pyproject
+    assert "pandas>=2.2.0" in pyproject
+    assert "pyarrow>=18.0.0" in pyproject
+    assert "click>=8.3.3" in pyproject
+    # commented catalog — present but off by default
+    assert '#   "torch>=' in pyproject
+    assert '#   "transformers>=' in pyproject
+    assert '#   "scikit-learn>=' in pyproject
+    assert '#   "jax>=' in pyproject
+    # notebooks group covers Jupyter + IPython + marimo
+    assert "jupyterlab>=4.5.7" in pyproject
+    assert "ipykernel>=7.0.0" in pyproject
+    assert "marimo>=0.23.4" in pyproject
+    assert "py313" in pyproject
+    assert 'packages = ["src/my_ds_app"]' in pyproject
+    assert 'build-backend = "hatchling.build"' in pyproject
+
+
+def test_scaffold_files_ds_data_module(tmp_path: Path) -> None:
+    target = tmp_path / "my-ds-app"
+    target.mkdir()
+    scaffold_files(target, name="my-ds-app", module_name="my_ds_app", archetype="ds", python_version="3.13")
+    data_content = (target / "src" / "my_ds_app" / "data.py").read_text()
+    assert "import pandas as pd" in data_content
+    assert "read_parquet" in data_content
+    assert "def summary" in data_content
+    config = (target / "src" / "my_ds_app" / "config.py").read_text()
+    assert "pydantic_settings" in config
+
+
+def test_scaffold_files_ds_gitignore_has_ml_entries(tmp_path: Path) -> None:
+    target = tmp_path / "my-ds-app"
+    target.mkdir()
+    scaffold_files(target, name="my-ds-app", module_name="my_ds_app", archetype="ds", python_version="3.13")
+    content = (target / ".gitignore").read_text()
+    assert "*.safetensors" in content
+    assert "mlruns/" in content
+    assert "wandb/" in content
+    assert ".ipynb_checkpoints/" in content
+    assert "__marimo__/" in content
+    assert ".cache/huggingface/" in content
+
+
+def test_scaffold_files_ds_end_with_trailing_newline(tmp_path: Path) -> None:
+    target = tmp_path / "my-ds-app"
+    target.mkdir()
+    scaffold_files(target, name="my-ds-app", module_name="my_ds_app", archetype="ds", python_version="3.13")
+
+    generated_files = [
+        ".python-version",
+        ".gitignore",
+        "main.py",
+        "pyproject.toml",
+        "README.md",
+        "src/my_ds_app/__init__.py",
+        "src/my_ds_app/_logging.py",
+        "src/my_ds_app/config.py",
+        "src/my_ds_app/data.py",
+        "src/my_ds_app/main.py",
+        "tests/__init__.py",
+        "tests/conftest.py",
+        "tests/test_data.py",
+        "notebooks/explore.ipynb",
+        "notebooks/explore_marimo.py",
+    ]
+
+    for rel_path in generated_files:
+        content = (target / rel_path).read_text()
+        assert content.endswith("\n"), f"Expected trailing newline in {rel_path}"
+
+
+# ---------------------------------------------------------------------------
+# ds archetype — integration & CLI
+# ---------------------------------------------------------------------------
+
+
+def test_run_new_ds_success(tmp_path: Path) -> None:
+    with (
+        patch("nuv.commands.new.shutil.which", return_value="/usr/bin/uv"),
+        patch("nuv.commands.new.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = run_new("my-ds-app", at=str(tmp_path / "my-ds-app"), cwd=tmp_path, archetype="ds")
+    assert result == 0
+    assert (tmp_path / "my-ds-app" / "src" / "my_ds_app" / "data.py").exists()
+    assert (tmp_path / "my-ds-app" / "notebooks" / "explore.ipynb").exists()
+    assert (tmp_path / "my-ds-app" / "models").exists()
+
+
+def test_run_new_ds_cleanup_on_failure(tmp_path: Path) -> None:
+    with patch("nuv.commands.new.shutil.which", return_value=None):
+        result = run_new("my-ds-app", cwd=tmp_path, archetype="ds")
+    assert result == 1
+    assert not (tmp_path / "my-ds-app").exists()
+
+
+def test_cli_new_ds_archetype(tmp_path: Path) -> None:
+    with (
+        patch("nuv.commands.new.shutil.which", return_value="/usr/bin/uv"),
+        patch("nuv.commands.new.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = cli_main(["new", "my-ds-app", "--at", str(tmp_path / "my-ds-app"), "--archetype", "ds"])
+    assert result == 0
+    assert (tmp_path / "my-ds-app" / "src" / "my_ds_app" / "__init__.py").exists()
+    assert (tmp_path / "my-ds-app" / "notebooks" / "explore_marimo.py").exists()
+
+
+def test_cli_ds_default_python_version(tmp_path: Path) -> None:
+    with (
+        patch("nuv.commands.new.shutil.which", return_value="/usr/bin/uv"),
+        patch("nuv.commands.new.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = cli_main(["new", "my-ds-app", "--at", str(tmp_path / "my-ds-app"), "--archetype", "ds"])
+    assert result == 0
+    assert (tmp_path / "my-ds-app" / ".python-version").read_text().strip() == "3.13"


### PR DESCRIPTION
## Summary

A new `ds` archetype for data science work, built around a simple manifesto: **all of what you need or want, but off by default.**

```bash
nuv new my-ds-project --archetype ds
```

The generated `pyproject.toml` ships a deliberately thin **active core** — `numpy`, `pandas`, `pyarrow`, `click`, `pydantic-settings` — alongside a large, curated, **commented-out catalog** of the rest of the modern stack. Uncomment a line, run `uv sync`, and uv resolves it against everything already locked.

The catalog covers:
- **Dataframes & formats**: polars, duckdb, deltalake, fastparquet, openpyxl, sqlalchemy, fsspec/s3fs
- **Classical / tabular ML**: scikit-learn, scipy, statsmodels, xgboost, lightgbm, catboost, imbalanced-learn, optuna
- **Deep learning & neural nets**: torch (+vision/audio), lightning, tensorflow, keras, jax, flax, optax, einops
- **LLMs / transformers / NLP**: transformers, datasets, tokenizers, accelerate, peft, safetensors, sentence-transformers, bitsandbytes, vllm, tiktoken, openai, anthropic, ollama, langchain(+community), langgraph, llama-index, spacy, nltk, gensim
- **Vector stores**: faiss-cpu, chromadb, qdrant-client
- **Images/audio/geo**, **experiment tracking/orchestration** (mlflow, wandb, dvc, hydra, ray, dask), **viz** (matplotlib, seaborn, plotly, altair, bokeh), and utilities

Version floors track the latest major releases as of mid-2026.

## Notebooks

Both notebook front-ends ship side by side under the optional `notebooks` group:
- `notebooks/explore.ipynb` — Jupyter / IPython
- `notebooks/explore_marimo.py` — marimo

```bash
uv sync --group notebooks
uv run jupyter lab notebooks/
uv run marimo edit notebooks/explore_marimo.py
```

## Comprehensive gitignore

- The generated project's `.gitignore` is comprehensive for AI/ML work: datasets, model weights & checkpoints (`*.safetensors`, `*.ckpt`, `*.gguf`, `*.onnx`, ...), experiment-tracking dirs (`mlruns/`, `wandb/`, `lightning_logs/`, `ray_results/`), notebook & library caches, AI-agent dirs, and `.env` secrets.
- An equivalent **AI / ML / Data Science** section was added to this repo's own `.gitignore`.

## Green out of the box

Unlike the existing notebook-bearing archetypes, this one was validated end-to-end and is genuinely green:

```
uv run pytest          # 9 passed, 100% coverage
uv run ruff check .     # clean (marimo display idiom handled via per-file B018 ignore)
uv run ty check         # clean (optional notebooks excluded from the type-check pass)
```

Default Python version: **3.13** (broadest compatibility across the DS/ML ecosystem).

## Changes

- `src/nuv/templates/ds/` — new archetype templates (pyproject, config, data I/O, CLI, tests, marimo notebook, README, gitignore)
- `src/nuv/commands/new.py` — `_scaffold_ds`, `generate_ds_notebook`, default Python 3.13, dispatch + valid-archetype wiring
- `src/nuv/cli.py` — register `ds` archetype and update help text
- `tests/test_new.py` — full coverage for the new archetype (notebook generator, scaffold, integration, CLI)
- `.github/workflows/ci.yml` — `ds` integration smoke test (sync + pytest + ruff + ty)
- `README.md` — `ds` archetype section and manifesto
- `.gitignore` — AI/ML/DS section

## Test plan

- [x] `uv run pytest` (nuv) — 117 passed, 100% coverage
- [x] `uv run ruff check src/ tests/` + `ruff format --check` — clean
- [x] `uv run ty check src/` — clean
- [x] Generated `ds` project: `uv sync`, `pytest` (100% cov), `ruff check .`, `ty check` — all green
- [x] `explore.ipynb` valid JSON; `explore_marimo.py` compiles and `marimo export` succeeds

https://claude.ai/code/session_01BAidiiekWMsnjJ7U851Dia

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAidiiekWMsnjJ7U851Dia)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "ds" (data-science) archetype for scaffolding projects with CLI entrypoint, logging/config defaults, data I/O helpers, notebook support (Jupyter + Marimo), and starter layout including data/models dirs.

* **Documentation**
  * Updated README with usage examples and guidance for the new ds archetype and its workflow.

* **Tests**
  * Added unit and integration tests and fixtures to validate ds scaffolding, notebook generation, data helpers, and CLI behavior.

* **Chores**
  * Expanded .gitignore for AI/ML workflows and added a CI integration smoke test step targeting Python 3.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->